### PR TITLE
Fix asNumber() for NaN values

### DIFF
--- a/jsmin/nodes/div_expression.php
+++ b/jsmin/nodes/div_expression.php
@@ -37,6 +37,10 @@ class DivExpression extends BinaryExpression {
 				return null;
 			}
 
+			if (is_nan($left) || is_nan($right)) {
+				return NAN;
+			}
+
 			$expr = new Number(bcdiv($left, $right, 100));
 			return $expr->asNumber();
 		}


### PR DESCRIPTION
DivExpression->asNumber() did not handle the case such as
foo(0/(0/0)) due to bcdiv() reporting "Division by zero".
